### PR TITLE
Fixes Swift Language Version error

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,10 +5,12 @@
     <clobbers target="modusechoswift" />
   </js-module>
   <platform name="ios">
+    <dependency id="cordova-plugin-add-swift-support" version="1.7.2"/>
     <config-file target="config.xml" parent="/*">
       <feature name="ModusEchoSwift">
         <param name="ios-package" value="ModusEchoSwift" />
       </feature>
+      <preference name="UseSwiftLanguageVersion" value="3" />
     </config-file>
     <source-file src="src/ios/ModusEchoSwift.swift" />
   </platform>


### PR DESCRIPTION
When using a Swift 3 plugin, need to specify the version. This is done by adding a dependency to the cordova-plugin-add-swift-support and specifying the version.

“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift.